### PR TITLE
Explicitly tell the reader to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 ### The main bit
 
+First, follow the links to install the [main dependencies](main-dependencies)
+
 Start Minikube if you haven't already
 
 ```bash


### PR DESCRIPTION
My eyes brushed over the list of dependencies the first few times. I was about to file an issue suggesting that a list of dependencies and links to installation instructions should be provided.. but then I realized the list is already here, I just hadn't seen it because there's nothing to say it's an actionable list.

So here's a small hint to go back..