### PR TITLE
Update link to Skaffold quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - [Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/).
 - [KubeDB operator](https://kubedb.com/docs/v0.13.0-rc.0/setup/install/)
-- [Skaffold](https://skaffold.dev/docs/getting-started/)
+- [Skaffold](https://skaffold.dev/docs/quickstart/)
 - [kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md)
 - [jq](https://stedolan.github.io/jq/)
 - [MinIO client (mc)](https://min.io/download)


### PR DESCRIPTION
It seems that the URL was changed as 1.0.0 was released, and the old URL now 404s instead of redirecting to the new location