### PR TITLE
Note that localhost:8080 is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 - [jq](https://stedolan.github.io/jq/)
 - [MinIO client (mc)](https://min.io/download)
 
+- Clay's web interface needs to be accessible on http://localhost:8080/. If you have something already listening on this port, you won't get any errors, but you won't be able to connect to Clay to start a scraper. You'll need to clear that port.
+
 ### The main bit
 
 First, follow the links to install the [main dependencies](main-dependencies)


### PR DESCRIPTION
Expected behaviour:

Following the README, running `client.sh` should connect to the API server on `localhost:8080`.

Observed behaviour:
If there's already something listening on `localhost:8080`, no error messages are given, but requests will go to that service.