### PR TITLE
Makeify PPA setup for golang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: image server test build
+.PHONY: image server test build ppa
 
 all: run
 
@@ -10,6 +10,11 @@ test: install
 
 install:
 	go install ./...
+
+ppa:
+	sudo add-apt-repository ppa:longsleep/golang-backports
+	sudo apt-get update
+	sudo apt-get install golang-go
 
 mocks:
 	mockery -all -inpkg

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - [jq](https://stedolan.github.io/jq/)
 - [MinIO client (mc)](https://min.io/download)
 - [Go 1.13](https://golang.org/dl/)
-  - [Ubuntu PPA](https://github.com/golang/go/wiki/Ubuntu)
+  - Ubuntu - use `make ppa` or [read instructions](https://github.com/golang/go/wiki/Ubuntu)
   - [MacOS package installer](https://golang.org/doc/install#macos)
 
 - Clay's web interface needs to be accessible on [http://localhost:8080/](http://localhost:8080/). If you have something already listening on this port, you won't get any errors, but you won't be able to connect to Clay to start a scraper. You'll need to clear that port.


### PR DESCRIPTION
Add a Makefile target for setting up the PPA on ubuntu and isntalling Golang from the suggested PPA.

Alter README to suggest using this.

Follow-on from changes in #78 