### PR TITLE
Set $PATH to include the $GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: image server test build
 
+SHELL := /bin/bash
+PATH := $(shell GOPATH=$$(go env GOPATH);echo $${GOPATH//://bin:}/bin:$$PATH)
+
 all: run
 
 run: install


### PR DESCRIPTION
One possible fix for #83 

Downside of this approach is that it slightly obscures from the user what they would need to do if they want to set $GOPATH themselves.

Upside is that it means that someone who doesn't care about developing go and just wants to get a test environment up and running can just "make test".

But.. if they are going to need to set $PATH in order to run clay by hand later, maybe it'd be better to document doing that.