### PR TITLE
First draft - Build and run server inside vagrant box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 app
 assets/client-storage
 public
+.vagrant/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: image server test build ppa run website apidocs
+.PHONY: image server test build ppa run website apidocs skaffold kubectl minikube kustomize mc ppa go kubedb provision
 
 all: run
 
@@ -11,10 +11,10 @@ test: install
 install:
 	go install ./...
 
-ppa:
-	sudo add-apt-repository ppa:longsleep/golang-backports
-	sudo apt-get update
-	sudo apt-get install golang-go
+ppa: go
+
+kubedb:
+	curl -fsSL https://github.com/kubedb/installer/raw/v0.13.0-rc.0/deploy/kubedb.sh | bash
 
 mocks:
 	mockery -all -inpkg
@@ -31,6 +31,62 @@ minio_access_key = $(shell grep access_key configs/secrets-minio.env | cut -d "=
 minio_secret_key = $(shell grep secret_key configs/secrets-minio.env | cut -d "=" -f 2)
 minio_yinyo_access_key = $(shell grep store_access_key configs/secrets-yinyo-server.env | cut -d "=" -f 2)
 minio_yinyo_secret_key = $(shell grep store_secret_key configs/secrets-yinyo-server.env | cut -d "=" -f 2)
+
+/usr/local/bin/kubectl:
+	curl -#LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+	chmod +x ./kubectl
+	sudo install ./kubectl /usr/local/bin/
+
+/usr/local/bin/minikube:
+	curl -#LO minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+	chmod +x minikube
+	sudo install ./minikube /usr/local/bin/
+
+/usr/local/bin/skaffold:
+	curl -#LO skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
+	chmod +x skaffold
+	sudo install ./skaffold /usr/local/bin
+
+/usr/local/bin/kustomize:
+	curl -#LO https://api.github.com/repos/kubernetes-sigs/kustomize/releases | grep browser_download | grep linux | cut -d '"' -f 4 | grep /kustomize/v | sort | tail -n 1 | xargs curl -sSOL
+	tar xzf ./kustomize_v*_linux_amd64.tar.gz
+	chmod +x kustomize
+	sudo install ./kustomize /usr/local/bin
+
+/usr/local/bin/mc:
+	curl -#LO https://dl.min.io/client/mc/release/linux-amd64/mc
+	chmod +x mc
+	sudo install ./mc /usr/local/bin
+
+/usr/bin/go:
+	sudo add-apt-repository ppa:longsleep/golang-backports
+	sudo apt-get update
+	sudo apt-get install -y golang-go
+
+/usr/bin/docker:
+	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+	sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $$(lsb_release -cs) stable"
+	sudo apt install -y socat docker-ce docker-ce-cli containerd.io
+
+go: /usr/bin/go
+
+kustomize: /usr/local/bin/kustomize
+
+kubectl: /usr/local/bin/kubectl
+
+minikube: docker kubectl /usr/local/bin/minikube
+	minikube start --vm-driver=none  --kubernetes-version='v1.15.2'
+	
+skaffold: /usr/local/bin/skaffold
+
+mc: /usr/local/bin/mc docker kubedb
+
+docker: /usr/bin/docker
+
+provision: docker minikube skaffold kustomize mc go
+	curl -fsSL https://github.com/kubedb/installer/raw/v0.13.0-rc.0/deploy/kubedb.sh | bash
+	touch provision
+
 
 buckets:
 	echo "Waiting for Minio to start up..."

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,75 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$provisionscript = <<-SCRIPT
+cd /srv
+make provision
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-18.10"
+
+  #This box is set to 65Gb in size; should be enough for anybody.
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/srv"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  
+  config.vm.provider "virtualbox" do |v|
+    # More cpus and crank up the memory for a faster build
+    v.memory = 4096
+    v.cpus = 2
+  end
+
+  config.vm.provision "shell", inline: $provisionscript
+  
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end


### PR DESCRIPTION
The work done here is a partial implementation of #99 

This adds all the required pre-requisite install tasks into the Makefile in a simplistic way, and adds a Vagrantfile which uses this to build a VM which has all the pre-requisite steps completed.

To get a working yinyo server, it's still neccessary to run `skaffold` and `make buckets` as per the readme - as root, in `/srv` inside the VM.