### PR TITLE
Add link direct to project licence on Github

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -38,7 +38,7 @@ features:
     text: |
       Made specifically for developers of scraper systems be it open source or
       commercial. No chance of vendor lock-in because it's open source,
-      Apache licensed.
+      under the [Apache 2.0 license](https://github.com/openaustralia/yinyo/blob/master/LICENSE).
     draft: true
 ---
 


### PR DESCRIPTION
Link to the full licence rather than just mentioning it.