### PR TITLE
Automate release of binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,5 +2,6 @@ name: Release
 on: [release]
 jobs:
   release:
-  - name: Go Release Binary
-    uses: ngs/go-release.action@v1.0.2
+    steps:
+    - name: Go Release Binary
+      uses: ngs/go-release.action@v1.0.2


### PR DESCRIPTION
Uses https://github.com/marketplace/actions/go-release-binary as a base